### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,0 +1,1 @@
+< 3.4.0.beta2-dev: 284f6bf67a50ba85dbeb7b83392a85b46bcf4533

--- a/javascripts/discourse/components/pronunciation-control.gjs
+++ b/javascripts/discourse/components/pronunciation-control.gjs
@@ -111,7 +111,7 @@ export default class PronunciationControl extends Component {
             />
             <DButton
               @disabled={{this.isRecording}}
-              @icon="trash-alt"
+              @icon="trash-can"
               @action={{this.delete}}
               class="btn-danger"
             />


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.